### PR TITLE
Adds a constant for the Overcast XML export.

### DIFF
--- a/backcast.php
+++ b/backcast.php
@@ -1,0 +1,3 @@
+#!/usr/local/bin/php
+<?php
+define('XML_EXPORT_URL', './overcast.opml');


### PR DESCRIPTION
Assigns a constant to be used throughout the script of the XML file that's being processed for backing up XML files.